### PR TITLE
Add aria-label to slider button for better accessibility

### DIFF
--- a/src/Resources/views/plugin/moorl-foundation/listing.html.twig
+++ b/src/Resources/views/plugin/moorl-foundation/listing.html.twig
@@ -162,12 +162,12 @@
                     <div class="">
                         <div class="base-slider-controls"
                              data-product-slider-controls="true">
-                            <button class="{{ controlsPrevClasses|join(' ') }}">
+                            <button class="{{ controlsPrevClasses|join(' ') }}"  aria-label="{{ 'general.previous'|trans|striptags }}">
                                 {% block moorl_foundation_listing_slider_controls_items_prev_icon %}
                                     {% sw_icon 'arrow-head-left' %}
                                 {% endblock %}
                             </button>
-                            <button class="{{ controlsNextClasses|join(' ') }}">
+                            <button class="{{ controlsNextClasses|join(' ') }}" aria-label="{{ 'general.next'|trans|striptags }}">
                                 {% block moorl_foundation_listing_slider_controls_items_next_icon %}
                                     {% sw_icon 'arrow-head-right' %}
                                 {% endblock %}


### PR DESCRIPTION
Add aria-labels to buttons. 

See for example @Storefront/storefront/element/cms-element-image-gallery.html.twig, line 289 ff
```twig
<button class="base-slider-controls-prev gallery-slider-controls-prev{% if navigationArrows == " outside" %} is-nav-prev-outside{% elseif navigationArrows == " inside" %} is-nav-prev-inside{% endif %}" aria-label="{{ 'general.previous'|trans|striptags }}">
	{% block element_image_gallery_inner_control_prev_icon %}
		{% sw_icon 'arrow-head-left' %}
	{% endblock %}
</button>
```

Needed for wcag 2.1 aa